### PR TITLE
Standardize pv interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 No-code web drag and drop OPI builder for EPICS applications.
 
-> NOTE: This app is under development, so not all planned features are yet functional, but feel free to try it out!
+> NOTE: Follow the app development and mapped improvements on [EWS Project Dashboard](https://github.com/users/AndreFavotto/projects/2)
 
 The gateway between EPICS and the browser is done via [./pvaPyWS](./pvaPyWS).
 

--- a/src/components/PropertyEditor/PVListProperty.tsx
+++ b/src/components/PropertyEditor/PVListProperty.tsx
@@ -1,0 +1,40 @@
+// src/components/PropertyFields/PvListProperty.tsx
+import React from "react";
+import ListItem from "@mui/material/ListItem";
+import TextField from "@mui/material/TextField";
+import type { PropertyKey, PropertyValue } from "../../types/widgets";
+
+interface PvListPropertyProps {
+  propName: PropertyKey;
+  label: string;
+  value: PropertyValue;
+  onChange: (propName: PropertyKey, newValue: PropertyValue) => void;
+}
+
+const PvListProperty: React.FC<PvListPropertyProps> = ({ propName, label, value, onChange }) => {
+  if (typeof value !== "object" || value === null) {
+    console.warn(`PvListProperty expected Record<string,string>, got`, value);
+    return null;
+  }
+  const handleChange = (key: string, newVal: string) => {
+    onChange(propName, { ...value, [key]: newVal });
+  };
+
+  return (
+    <>
+      {Object.entries(value).map(([key, val]) => (
+        <ListItem key={key} disablePadding sx={{ px: 2, py: 1 }} title={label}>
+          <TextField
+            fullWidth
+            size="small"
+            label={key}
+            value={val}
+            onChange={(e) => handleChange(key, e.target.value)}
+          />
+        </ListItem>
+      ))}
+    </>
+  );
+};
+
+export default React.memo(PvListProperty);

--- a/src/components/PropertyEditor/PropertyEditor.tsx
+++ b/src/components/PropertyEditor/PropertyEditor.tsx
@@ -25,6 +25,7 @@ import BooleanProperty from "./BooleanProperty";
 import ColorProperty from "./ColorProperty";
 import SelectProperty from "./SelectProperty";
 import { CATEGORY_DISPLAY_ORDER } from "../../types/widgetProperties";
+import PvListProperty from "./PVListProperty";
 
 const openedMixin = (theme: Theme): CSSObject => ({
   width: PROPERTY_EDITOR_WIDTH,
@@ -204,6 +205,8 @@ const PropertyEditor: React.FC = () => {
                 case "text":
                 case "number":
                   return <TextFieldProperty key={propName} {...commonProps} selType={selType} />;
+                case "pvList":
+                  return <PvListProperty key={propName} {...commonProps} />;
                 case "boolean":
                   return <BooleanProperty key={propName} {...commonProps} />;
                 case "colorSelector":

--- a/src/components/Widgets/ActionButton/ActionButton.ts
+++ b/src/components/Widgets/ActionButton/ActionButton.ts
@@ -3,6 +3,7 @@ import { COMMON_PROPS, PROPERTY_SCHEMAS, TEXT_PROPS } from "../../../types/widge
 import type { Widget } from "../../../types/widgets";
 import SendIcon from "@mui/icons-material/Send";
 import { COLORS } from "../../../constants/constants";
+import type { PVData } from "../../../types/pvaPyWS";
 
 export const ActionButton: Widget = {
   id: "__ActionButton__",
@@ -11,13 +12,13 @@ export const ActionButton: Widget = {
   widgetIcon: SendIcon,
   widgetLabel: "Action Button",
   category: "Controls",
+  pvData: {} as PVData,
   editableProperties: {
     ...COMMON_PROPS,
     ...TEXT_PROPS,
     label: { ...PROPERTY_SCHEMAS.label, value: "Action Button" },
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: COLORS.buttonColor },
     pvName: PROPERTY_SCHEMAS.pvName,
-    pvValue: PROPERTY_SCHEMAS.pvValue,
     actionValue: PROPERTY_SCHEMAS.actionValue,
     disabled: PROPERTY_SCHEMAS.disabled,
   },

--- a/src/components/Widgets/BitIndicator/BitIndicator.ts
+++ b/src/components/Widgets/BitIndicator/BitIndicator.ts
@@ -2,6 +2,7 @@ import { BitIndicatorComp } from "./BitIndicatorComp";
 import { PROPERTY_SCHEMAS, COMMON_PROPS } from "../../../types/widgetProperties";
 import type { Widget } from "../../../types/widgets";
 import FlakyIcon from "@mui/icons-material/Flaky";
+import type { PVData } from "../../../types/pvaPyWS";
 
 const { borderRadius, backgroundColor, ...FILTERED_COMMON_PROPS } = COMMON_PROPS;
 
@@ -12,6 +13,7 @@ export const BitIndicator: Widget = {
   widgetIcon: FlakyIcon,
   widgetLabel: "Bit Indicator",
   category: "Monitoring",
+  pvData: {} as PVData,
   editableProperties: {
     ...FILTERED_COMMON_PROPS,
     width: { ...PROPERTY_SCHEMAS.width, value: 40 },
@@ -24,6 +26,5 @@ export const BitIndicator: Widget = {
     invertBitOrder: PROPERTY_SCHEMAS.invertBitOrder,
     spacing: PROPERTY_SCHEMAS.spacing,
     pvName: PROPERTY_SCHEMAS.pvName,
-    pvValue: PROPERTY_SCHEMAS.pvValue,
   },
 } as const;

--- a/src/components/Widgets/BitIndicator/BitIndicatorComp.tsx
+++ b/src/components/Widgets/BitIndicator/BitIndicatorComp.tsx
@@ -5,6 +5,7 @@ import { useEditorContext } from "../../../context/useEditorContext";
 
 const BitIndicatorComp: React.FC<WidgetUpdate> = ({ data }) => {
   const p = data.editableProperties;
+  const pvData = data.pvData;
   const { mode } = useEditorContext();
 
   if (!p.visible?.value) return null;
@@ -14,8 +15,7 @@ const BitIndicatorComp: React.FC<WidgetUpdate> = ({ data }) => {
   const offColor = p.offColor?.value;
   const invertOrder = p.invertBitOrder?.value;
   const orientation = p.orientation?.value;
-
-  const value = mode === RUNTIME_MODE ? Number(p.pvValue?.value ?? 0) : 0;
+  const value = mode === RUNTIME_MODE ? Number(pvData?.value ?? 0) : 0;
 
   let bitIndexes = Array.from({ length: bitsCount }, (_, i) => i);
   if (invertOrder) {

--- a/src/components/Widgets/InputField/InputField.ts
+++ b/src/components/Widgets/InputField/InputField.ts
@@ -3,6 +3,7 @@ import { COLORS } from "../../../constants/constants";
 import type { Widget } from "../../../types/widgets";
 import InputIcon from "@mui/icons-material/Input";
 import { PROPERTY_SCHEMAS, COMMON_PROPS, TEXT_PROPS } from "../../../types/widgetProperties";
+import type { PVData } from "../../../types/pvaPyWS";
 
 export const InputField: Widget = {
   id: "__InputField__",
@@ -11,12 +12,12 @@ export const InputField: Widget = {
   widgetIcon: InputIcon,
   widgetLabel: "Input Field",
   category: "Controls",
+  pvData: {} as PVData,
   editableProperties: {
     ...COMMON_PROPS,
     ...TEXT_PROPS,
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: COLORS.inputColor },
     pvName: PROPERTY_SCHEMAS.pvName,
-    pvValue: PROPERTY_SCHEMAS.pvValue,
     disabled: PROPERTY_SCHEMAS.disabled,
   },
 } as const;

--- a/src/components/Widgets/Plot/Plot.tsx
+++ b/src/components/Widgets/Plot/Plot.tsx
@@ -4,6 +4,9 @@ import type { Widget } from "../../../types/widgets";
 import TimelineIcon from "@mui/icons-material/Timeline";
 import type { MultiPvData } from "../../../types/pvaPyWS";
 
+export const YAxisPVLabel = "Y Axis PV";
+export const XAxisPVLabel = "X Axis PV (optional)";
+
 export const Plot: Widget = {
   id: "__PlotComp__",
   component: PlotComp,
@@ -17,7 +20,7 @@ export const Plot: Widget = {
     width: { ...PROPERTY_SCHEMAS.width, value: 480 },
     height: { ...PROPERTY_SCHEMAS.height, value: 260 },
     ...TEXT_PROPS,
-    pvNames: { ...PROPERTY_SCHEMAS.pvNames, value: { "Y Axis": "", "X Axis:": "" } },
+    pvNames: { ...PROPERTY_SCHEMAS.pvNames, value: { [YAxisPVLabel]: "", [XAxisPVLabel]: "" } },
     ...PLOT_PROPS,
   },
 } as const;

--- a/src/components/Widgets/Plot/Plot.tsx
+++ b/src/components/Widgets/Plot/Plot.tsx
@@ -2,6 +2,7 @@ import { PlotComp } from "./PlotComp";
 import { COMMON_PROPS, PLOT_PROPS, PROPERTY_SCHEMAS, TEXT_PROPS } from "../../../types/widgetProperties";
 import type { Widget } from "../../../types/widgets";
 import TimelineIcon from "@mui/icons-material/Timeline";
+import type { MultiPvData } from "../../../types/pvaPyWS";
 
 export const Plot: Widget = {
   id: "__PlotComp__",
@@ -10,13 +11,13 @@ export const Plot: Widget = {
   widgetIcon: TimelineIcon,
   widgetLabel: "Graphic Plot",
   category: "Monitoring",
+  multiPvData: {} as MultiPvData,
   editableProperties: {
     ...COMMON_PROPS,
     width: { ...PROPERTY_SCHEMAS.width, value: 480 },
     height: { ...PROPERTY_SCHEMAS.height, value: 260 },
     ...TEXT_PROPS,
-    pvName: PROPERTY_SCHEMAS.pvName,
-    pvValue: PROPERTY_SCHEMAS.pvValue,
+    pvNames: { ...PROPERTY_SCHEMAS.pvNames, value: { "Y Axis": "", "X Axis:": "" } },
     ...PLOT_PROPS,
   },
 } as const;

--- a/src/components/Widgets/Plot/PlotComp.tsx
+++ b/src/components/Widgets/Plot/PlotComp.tsx
@@ -23,8 +23,11 @@ const PlotComp: React.FC<WidgetUpdate> = ({ data }) => {
   const [yBuffer, setYBuffer] = useState<number[]>([]);
   const [xBuffer, setXBuffer] = useState<number[]>([]);
 
-  const yVal = data.multiPvData?.[YAxisPVLabel]?.value;
-  const xVal = data.multiPvData?.[XAxisPVLabel]?.value;
+  const yPVName = p.pvNames?.value?.[YAxisPVLabel];
+  const xPVName = p.pvNames?.value?.[XAxisPVLabel];
+
+  const yVal = yPVName ? data.multiPvData?.[yPVName]?.value : undefined;
+  const xVal = xPVName ? data.multiPvData?.[xPVName]?.value : undefined;
 
   // --- Y effect
   useEffect(() => {

--- a/src/components/Widgets/Plot/PlotComp.tsx
+++ b/src/components/Widgets/Plot/PlotComp.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import type { WidgetUpdate } from "../../../types/widgets";
 import Plot from "react-plotly.js";
 import { useEditorContext } from "../../../context/useEditorContext";
 import { COLORS, EDIT_MODE } from "../../../constants/constants";
+import { XAxisPVLabel, YAxisPVLabel } from "./Plot";
 
 function usePrev<T>(value: T): T | undefined {
   const ref = useRef<T | undefined>(undefined);
@@ -18,20 +19,14 @@ const PlotComp: React.FC<WidgetUpdate> = ({ data }) => {
   const prevInEditMode = usePrev(inEditMode);
   const p = data.editableProperties;
   const bufferSize = p.plotBufferSize?.value ?? 50;
-  const YAxisPVLabel = "Y Axis";
-  const XAxisPVLabel = "X Axis";
 
   const [yBuffer, setYBuffer] = useState<number[]>([]);
   const [xBuffer, setXBuffer] = useState<number[]>([]);
 
-  const getPvValue = useCallback(
-    (axisPVLabel: string) => {
-      return data.multiPvData?.[axisPVLabel]?.value;
-    },
-    [data.multiPvData]
-  );
+  const yVal = data.multiPvData?.[YAxisPVLabel]?.value;
+  const xVal = data.multiPvData?.[XAxisPVLabel]?.value;
 
-  // update Y values
+  // --- Y effect
   useEffect(() => {
     if (prevInEditMode !== undefined && prevInEditMode !== inEditMode) {
       setYBuffer([]);
@@ -44,7 +39,6 @@ const PlotComp: React.FC<WidgetUpdate> = ({ data }) => {
       return;
     }
 
-    const yVal = getPvValue(YAxisPVLabel);
     if (typeof yVal === "number") {
       setYBuffer((prev) => {
         const next = [...prev, yVal];
@@ -54,12 +48,12 @@ const PlotComp: React.FC<WidgetUpdate> = ({ data }) => {
     } else if (Array.isArray(yVal) && yVal.every((v) => typeof v === "number")) {
       setYBuffer(yVal);
     }
-  }, [getPvValue, inEditMode, prevInEditMode, bufferSize]);
+  }, [yVal, inEditMode, prevInEditMode, bufferSize]);
 
-  // update X values
+  // --- X effect
   useEffect(() => {
     if (inEditMode) return;
-    const xVal = getPvValue(XAxisPVLabel);
+
     if (typeof xVal === "number") {
       setXBuffer((prev) => {
         const next = [...prev, xVal];
@@ -69,7 +63,7 @@ const PlotComp: React.FC<WidgetUpdate> = ({ data }) => {
     } else if (Array.isArray(xVal) && xVal.every((v) => typeof v === "number")) {
       setXBuffer(xVal);
     }
-  }, [getPvValue, inEditMode, bufferSize]);
+  }, [xVal, inEditMode, bufferSize]);
 
   return (
     <div

--- a/src/components/Widgets/TextUpdate/TextUpdate.ts
+++ b/src/components/Widgets/TextUpdate/TextUpdate.ts
@@ -3,6 +3,7 @@ import { PROPERTY_SCHEMAS, COMMON_PROPS, TEXT_PROPS } from "../../../types/widge
 import { COLORS } from "../../../constants/constants";
 import type { Widget } from "../../../types/widgets";
 import TextsmsIcon from "@mui/icons-material/Textsms";
+import type { PVData } from "../../../types/pvaPyWS";
 
 export const TextUpdate: Widget = {
   id: "__TextUpdate__",
@@ -11,12 +12,12 @@ export const TextUpdate: Widget = {
   widgetIcon: TextsmsIcon,
   widgetLabel: "Text Update",
   category: "Monitoring",
+  pvData: {} as PVData,
   editableProperties: {
     ...COMMON_PROPS,
     ...TEXT_PROPS,
     label: { ...PROPERTY_SCHEMAS.label, value: "Text Update" },
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: COLORS.readColor },
     pvName: PROPERTY_SCHEMAS.pvName,
-    pvValue: PROPERTY_SCHEMAS.pvValue,
   },
 } as const;

--- a/src/components/Widgets/TextUpdate/TextUpdateComp.tsx
+++ b/src/components/Widgets/TextUpdate/TextUpdateComp.tsx
@@ -5,6 +5,7 @@ import { useEditorContext } from "../../../context/useEditorContext";
 
 const TextUpdateComp: React.FC<WidgetUpdate> = ({ data }) => {
   const p = data.editableProperties;
+  const pvData = data.pvData;
   const { mode } = useEditorContext();
 
   if (!p.visible?.value) return null;
@@ -31,7 +32,7 @@ const TextUpdateComp: React.FC<WidgetUpdate> = ({ data }) => {
         borderColor: p.borderColor?.value,
       }}
     >
-      {mode == RUNTIME_MODE ? p.pvValue?.value : p.pvName?.value ?? p.label?.value}
+      {mode == RUNTIME_MODE ? pvData?.value : p.pvName?.value ?? p.label?.value}
     </div>
   );
 };

--- a/src/context/EditorProvider.tsx
+++ b/src/context/EditorProvider.tsx
@@ -9,10 +9,10 @@ export type EditorContextType = ReturnType<typeof useWidgetManager> &
 
 export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const widgetManager = useWidgetManager();
-  const ws = usePvaPyWS(widgetManager.editorWidgets, widgetManager.batchWidgetUpdate);
+  const ws = usePvaPyWS(widgetManager.PVList, widgetManager.updatePVData);
   const ui = useUIManager(
     ws.ws,
-    ws.clearPVValues,
+    widgetManager.clearPVData,
     ws.startNewSession,
     widgetManager.setSelectedWidgetIDs,
     widgetManager.updateWidgetProperties

--- a/src/context/usePvaPyWS.ts
+++ b/src/context/usePvaPyWS.ts
@@ -13,7 +13,7 @@ export default function usePvaPyWS(
 
   const parseWSMessage = (msg: WSMessage): PVData => {
     return {
-      name: msg.pv,
+      pv: msg.pv,
       value: msg.value ?? "",
       alarm: msg.alarm,
       timeStamp: msg.timeStamp,

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -491,7 +491,7 @@ export function useWidgetManager() {
     updateEditorWidgetList((prev) =>
       prev.map((w) => {
         // --- single PV case
-        if (w.editableProperties.pvName?.value === newPVData.name) {
+        if (w.editableProperties.pvName?.value === newPVData.pv) {
           return {
             ...w,
             pvData: {
@@ -509,7 +509,7 @@ export function useWidgetManager() {
           };
 
           for (const [label, pv] of Object.entries(w.editableProperties.pvNames.value)) {
-            if (pv === newPVData.name) {
+            if (pv === newPVData.pv) {
               updatedMultiPvData[label] = {
                 ...w.multiPvData?.[label],
                 ...newPVData,

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -11,6 +11,7 @@ import type {
 import { GridZone } from "../components/GridZone";
 import { GRID_ID, MAX_HISTORY } from "../constants/constants";
 import WidgetRegistry from "../components/WidgetRegistry/WidgetRegistry";
+import type { PVData } from "../types/pvaPyWS";
 
 function deepCloneWidgetList(widgets: Widget[]): Widget[] {
   return widgets.map(deepCloneWidget);
@@ -461,7 +462,7 @@ export function useWidgetManager() {
               return null;
             }
 
-            // deep clone the registry entry so we don’t mutate the registry itself
+            // deep clone the registry entry so we don't mutate the registry itself
             const instance = deepCloneWidget(baseWdg);
             instance.id = raw.id;
 
@@ -485,6 +486,78 @@ export function useWidgetManager() {
     },
     [updateEditorWidgetList]
   );
+
+  const updatePVData = (newPVData: PVData) => {
+    updateEditorWidgetList((prev) =>
+      prev.map((w) => {
+        // --- single PV case
+        if (w.editableProperties.pvName?.value === newPVData.name) {
+          return {
+            ...w,
+            pvData: {
+              ...w.pvData,
+              ...newPVData,
+              value: newPVData.value ?? w.pvData?.value,
+            },
+          };
+        }
+
+        // --- multi PV case
+        if (w.editableProperties.pvNames) {
+          const updatedMultiPvData: Record<string, PVData> = {
+            ...w.multiPvData,
+          };
+
+          for (const [label, pv] of Object.entries(w.editableProperties.pvNames.value)) {
+            if (pv === newPVData.name) {
+              updatedMultiPvData[label] = {
+                ...w.multiPvData?.[label],
+                ...newPVData,
+                value: newPVData.value ?? w.multiPvData?.[label]?.value,
+              };
+            }
+          }
+
+          return {
+            ...w,
+            multiPvData: updatedMultiPvData,
+          };
+        }
+        return w;
+      })
+    );
+  };
+
+  const clearPVData = () => {
+    updateEditorWidgetList(
+      (prev) =>
+        prev.map((w) => {
+          if (w.pvData) {
+            return { ...w, pvData: {} as PVData };
+          } else if (w.multiPvData) {
+            return { ...w, multiPvData: {} as Record<string, PVData> };
+          }
+          return w;
+        }),
+      false
+    );
+  };
+
+  const PVList = useMemo(() => {
+    const set = new Set<string>();
+    for (const w of editorWidgets) {
+      if (w.editableProperties?.pvName?.value) {
+        set.add(w.editableProperties.pvName.value);
+      }
+      const multiPV = w.editableProperties?.pvNames?.value;
+      if (multiPV) {
+        Object.values(multiPV).forEach((pv) => {
+          if (pv) set.add(pv);
+        });
+      }
+    }
+    return Array.from(set);
+  }, [editorWidgets]);
 
   return {
     editorWidgets,
@@ -519,5 +592,8 @@ export function useWidgetManager() {
     distributeVertical,
     downloadWidgets,
     loadWidgets,
+    updatePVData,
+    clearPVData,
+    PVList,
   };
 }

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -508,12 +508,12 @@ export function useWidgetManager() {
             ...w.multiPvData,
           };
 
-          for (const [label, pv] of Object.entries(w.editableProperties.pvNames.value)) {
+          for (const pv of Object.values(w.editableProperties.pvNames.value)) {
             if (pv === newPVData.pv) {
-              updatedMultiPvData[label] = {
-                ...w.multiPvData?.[label],
+              updatedMultiPvData[pv] = {
+                ...w.multiPvData?.[pv],
                 ...newPVData,
-                value: newPVData.value ?? w.multiPvData?.[label]?.value,
+                value: newPVData.value ?? w.multiPvData?.[pv]?.value,
               };
             }
           }

--- a/src/types/pvaPyWS.ts
+++ b/src/types/pvaPyWS.ts
@@ -1,7 +1,5 @@
 export type WSMessageType = "update" | "subscribe" | "unsubscribe" | "write";
-export type PVScalar = number | string;
-export type PVArray = number[] | string[];
-export type PVValue = PVScalar | PVArray;
+export type PVValue = number | number[] | string | string[];
 
 interface Alarm {
   severity: number;
@@ -60,3 +58,15 @@ export interface WSMessage {
   b64srt?: string;
   b64byt?: string;
 }
+
+export interface PVData {
+  name: string;
+  value: PVValue;
+  alarm?: Alarm;
+  timeStamp?: TimeStamp;
+  display?: Display;
+  control?: Control;
+  valueAlarm?: ValueAlarm;
+}
+
+export type MultiPvData = Record<string, PVData>;

--- a/src/types/pvaPyWS.ts
+++ b/src/types/pvaPyWS.ts
@@ -1,6 +1,6 @@
 export type WSMessageType = "update" | "subscribe" | "unsubscribe" | "write";
 export type PVValue = number | number[] | string | string[];
-
+// structure based on EPICS Normative Types
 interface Alarm {
   severity: number;
   status: number;
@@ -60,7 +60,7 @@ export interface WSMessage {
 }
 
 export interface PVData {
-  name: string;
+  pv: string;
   value: PVValue;
   alarm?: Alarm;
   timeStamp?: TimeStamp;

--- a/src/types/widgetProperties.ts
+++ b/src/types/widgetProperties.ts
@@ -40,7 +40,7 @@ export const PROPERTY_SCHEMAS = {
   centerVisible:   defineProp({ selType: "boolean", label: "Center mark visible", value: true as boolean, category: "Grid" }),
   // EPICS
   pvName:          defineProp({ selType: "text", label: "PV Name", value: "" as string, category: "EPICS" }),
-  pvNames:         defineProp({ selType: "pvList", label: "PV Names", value: {} as Record<string, string>, category: "EPICS" }), //to be implemented
+  pvNames:         defineProp({ selType: "pvList", label: "PV Names", value: {} as Record<string, string>, category: "EPICS" }),
   precisionFromPV: defineProp({ selType: "boolean", label: "Disabled", value: true as boolean, category: "EPICS" }),
   actionValue:     defineProp({ selType: "text", label: "Action Value", value: 1 as number | string, category: "EPICS" }),
   // Specific Properties
@@ -55,11 +55,11 @@ export const PROPERTY_SCHEMAS = {
   //Graph
   lineColor:       defineProp({ selType: "colorSelector", label: "Line Color", value: COLORS.graphLineColor, category: "Style" }),
   plotTitle:       defineProp({ selType: "text", label: "Title", value: "Title" as string, category: "Layout" }),
-  xAxisTitle:      defineProp({ selType: "text", label: "X axis title", value: "Time" as string, category: "Layout" }),
+  xAxisTitle:      defineProp({ selType: "text", label: "X axis title", value: "X axis" as string, category: "Layout" }),
   yAxisTitle:      defineProp({ selType: "text", label: "Y axis title", value: "Y axis" as string, category: "Layout" }),
   logscaleY:       defineProp({ selType: "boolean", label: "Apply log to Y", value: false as boolean, category: "Layout" }),
-  plotLineStyle:   defineProp({ selType: "select", label: "Line style", value: "lines+markers" as "lines+markers"|"lines"|"markers", options: ["lines+markers", "lines", "markers"], category: "Style" }),
-  plotBufferSize:  defineProp({ selType: "number", label: "Buffer size (if scalar PVs)", value: 50 as number, category: "Layout" }),
+  plotLineStyle:   defineProp({ selType: "select", label: "Line style", value: "lines" as "lines+markers"|"lines"|"markers", options: ["lines+markers", "lines", "markers"], category: "Style" }),
+  plotBufferSize:  defineProp({ selType: "number", label: "Buffer size (if scalar PVs)", value: 80 as number, category: "Layout" }),
 };
 
 export const CATEGORY_DISPLAY_ORDER = ["Grid", "Layout", "Style", "Font", "General", "EPICS", "Window", "Other"];

--- a/src/types/widgetProperties.ts
+++ b/src/types/widgetProperties.ts
@@ -1,6 +1,5 @@
 import type { WidgetProperty, PropertyValue, WidgetProperties } from "./widgets";
 import { COLORS } from "../constants/constants";
-import type { PVValue } from "./pvaPyWS";
 
 /* helper to make sure each property value is correctly typed */
 function defineProp<T extends PropertyValue>(prop: WidgetProperty<T>): WidgetProperty<T> {
@@ -41,11 +40,9 @@ export const PROPERTY_SCHEMAS = {
   centerVisible:   defineProp({ selType: "boolean", label: "Center mark visible", value: true as boolean, category: "Grid" }),
   // EPICS
   pvName:          defineProp({ selType: "text", label: "PV Name", value: "" as string, category: "EPICS" }),
+  pvNames:         defineProp({ selType: "pvList", label: "PV Names", value: {} as Record<string, string>, category: "EPICS" }), //to be implemented
   precisionFromPV: defineProp({ selType: "boolean", label: "Disabled", value: true as boolean, category: "EPICS" }),
   actionValue:     defineProp({ selType: "text", label: "Action Value", value: 1 as number | string, category: "EPICS" }),
-  pvValue:         defineProp({ selType: "none", label: "PV Value", value: "" as PVValue, category: "EPICS" }),
-  // placeholder for number array - needed for now to match all types in PropertyValue
-  placeholder:     defineProp({ selType: "select", label: "placeholder prop", value: [] as number[], category: "placeholder" }),
   // Specific Properties
   // BitIndicator
   orientation:     defineProp({ selType: "select", label: "Orientation", value: "Vertical" as string, options: ["Vertical", "Horizontal"], category: "Layout" }),
@@ -62,8 +59,6 @@ export const PROPERTY_SCHEMAS = {
   yAxisTitle:      defineProp({ selType: "text", label: "Y axis title", value: "Y axis" as string, category: "Layout" }),
   logscaleY:       defineProp({ selType: "boolean", label: "Apply log to Y", value: false as boolean, category: "Layout" }),
   plotLineStyle:   defineProp({ selType: "select", label: "Line style", value: "lines+markers" as "lines+markers"|"lines"|"markers", options: ["lines+markers", "lines", "markers"], category: "Style" }),
-  xAxisPVName:     defineProp({ selType: "text", label: "X axis PV", value: "" as string, category: "EPICS" }),
-  xAxisPVValue:    defineProp({ selType: "none", label: "X axis PV value", value: "" as PVValue, category: "EPICS" }),
   plotBufferSize:  defineProp({ selType: "number", label: "Buffer size (if scalar PVs)", value: 50 as number, category: "Layout" }),
 };
 
@@ -105,7 +100,5 @@ export const PLOT_PROPS: WidgetProperties = {
   yAxisTitle: PROPERTY_SCHEMAS.yAxisTitle,
   plotLineStyle: PROPERTY_SCHEMAS.plotLineStyle,
   logscaleY: PROPERTY_SCHEMAS.logscaleY,
-  xAxisPVName: PROPERTY_SCHEMAS.xAxisPVName,
-  xAxisPVValue: PROPERTY_SCHEMAS.xAxisPVValue,
   plotBufferSize: PROPERTY_SCHEMAS.plotBufferSize,
 };

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -1,8 +1,9 @@
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import { PROPERTY_SCHEMAS } from "./widgetProperties";
+import type { MultiPvData, PVData } from "./pvaPyWS";
 
-export type PropertySelectorType = "text" | "number" | "boolean" | "colorSelector" | "select" | "none";
-export type PropertyValue = string | string[] | number | number[] | boolean;
+export type PropertySelectorType = "text" | "number" | "boolean" | "colorSelector" | "select" | "pvList" | "none";
+export type PropertyValue = string | number | boolean | Record<string, string>;
 export interface WidgetProperty<T extends PropertyValue = PropertyValue> {
   selType: PropertySelectorType;
   label: string;
@@ -28,6 +29,8 @@ export interface Widget {
   id: string;
   widgetLabel: string;
   widgetIcon?: WidgetIconType;
+  pvData?: PVData;
+  multiPvData?: MultiPvData;
   widgetName: string;
   component: React.FC<WidgetUpdate>;
   category: string;


### PR DESCRIPTION
All pv data is now accessible by the widgets through a standard interface via the property `pvData`. See [PVData type](https://github.com/AndreFavotto/EpicsWebStudio/blob/standardize-pv-interface/src/types/pvaPyWS.ts#L62). 

For widgets that support multiple PVs (e.g., plot), two additional optional properties were added: pvNames (editable  `Record<string, string>`) and multiPvData (`Record<string, PVData>`). 

pvNames is of type pvList. The UI PV labels (keys) can be defined on component instantiation, and user defines the pv names (values). Then, on update, values are stored in MultiPVData having the PVs as keys and PVData as values. See [Plot component](https://github.com/AndreFavotto/EpicsWebStudio/tree/standardize-pv-interface/src/components/Widgets/Plot)

Closes #14 